### PR TITLE
fix: add account status check to prevent login for banned users

### DIFF
--- a/apps/api/src/modules/auth/auth.module.ts
+++ b/apps/api/src/modules/auth/auth.module.ts
@@ -1,4 +1,4 @@
-import { forwardRef, Module } from '@nestjs/common';
+import { forwardRef, Logger, Module } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { AuthController } from './auth.controller';
 import { JwtModule } from '@nestjs/jwt';
@@ -27,7 +27,7 @@ import { GoogleStrategy } from './google.strategy';
     forwardRef(() => AccountsModule), // use forwardRef iff there is a circular dep
   ],
   controllers: [AuthController],
-  providers: [AuthService, LocalStrategy, JwtStrategy, GoogleStrategy],
+  providers: [AuthService, LocalStrategy, JwtStrategy, GoogleStrategy, Logger],
   exports: [AuthService, JwtStrategy],
 })
 export class AuthModule {}

--- a/apps/api/src/modules/auth/auth.service.ts
+++ b/apps/api/src/modules/auth/auth.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
 import { AccountsService } from '../accounts/accounts.service';
 import { comparePassword } from '../../shared/helpers/account.helper';
 import { JwtService } from '@nestjs/jwt';
@@ -22,7 +22,7 @@ export class AuthService {
     private readonly accountsService: AccountsService,
     private readonly jwtService: JwtService,
     private readonly configService: ConfigService,
-    private readonly logger: Console,
+    private readonly logger: Logger,
   ) {}
 
   /** seconds */


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Add account status validation to prevent banned users from logging in

- Implement status check for both email/password and Google OAuth authentication

- Return appropriate error message for banned accounts


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Login Request"] --> B["Validate Credentials"]
  B --> C["Check Account Status"]
  C --> D{Status = BANNED?}
  D -->|Yes| E["Throw UnauthorizedException"]
  D -->|No| F["Generate JWT Tokens"]
  F --> G["Return Login Response"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>auth.service.ts</strong><dd><code>Add banned account status validation to authentication</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/src/modules/auth/auth.service.ts

<ul><li>Import <code>AccountStatus</code> enum for status validation<br> <li> Add banned account check in <code>validateAccount</code> method after password <br>verification<br> <li> Add banned account check in <code>loginWithGoogle</code> method after account <br>upsert<br> <li> Update code comments to reflect new validation step numbering</ul>


</details>


  </td>
  <td><a href="https://github.com/lgdlong/g3-swp391-2hand-ev-battery-trading/pull/125/files#diff-6f94ed33079efa3def3644a6bd947187d344479602b3dfae7dafacc50ebbc45f">+15/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

